### PR TITLE
Update tools & CI

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -43,7 +43,7 @@ jobs:
       working-directory: ${{github.workspace}}/build
       run: |
         ctest -V -C $BUILD_TYPE
-        gcovr -j $(nproc) --delete --root ../source/ -e '^test/.*' --print-summary --xml-pretty --xml coverage.xml .
+        gcovr -j $(nproc) --delete --root ../source/ -e '\.\./source/test/.*' --print-summary --xml-pretty --xml coverage.xml .
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v2

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -23,6 +23,10 @@ jobs:
       with:
         cmake-version: 3.18
 
+    - name: Set up gcc-11 & g++-11
+      run: |
+        sudo apt-get install gcc-11 g++-11
+
     - name: Set up gcovr
       run: |
         pip install gcovr
@@ -31,6 +35,9 @@ jobs:
       run: |
         cmake -D CMAKE_BUILD_TYPE=$BUILD_TYPE -D CXXP_ENABLE_COVERAGE=ON -B build -S .
         cmake --build build --config $BUILD_TYPE
+      env:
+        CC: gcc-11
+        CXX: g++-11
 
     - name: Run tests & generate coverage
       working-directory: ${{github.workspace}}/build

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -43,7 +43,7 @@ jobs:
       working-directory: ${{github.workspace}}/build
       run: |
         ctest -V -C $BUILD_TYPE
-        gcovr -j $(nproc) --delete --root ../source/ --print-summary --xml-pretty --xml coverage.xml .
+        gcovr -j $(nproc) --delete --root ../source/ -e *.test.cpp --print-summary --xml-pretty --xml coverage.xml .
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v2

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -23,10 +23,17 @@ jobs:
       with:
         cmake-version: 3.18
 
+    - name: Install GCC 11
+      run: |
+          sudo apt-get install gcc-11 g++-11
+
     - name: Build
       run: |
         cmake -D CMAKE_BUILD_TYPE=$BUILD_TYPE -D CXXP_ENABLE_COVERAGE=ON -B build -S .
         cmake --build build --config $BUILD_TYPE
+      env:
+        CC: gcc-11
+        CXX: g++-11
 
     - name: Run tests
       working-directory: ${{github.workspace}}/build

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -43,7 +43,7 @@ jobs:
       working-directory: ${{github.workspace}}/build
       run: |
         ctest -V -C $BUILD_TYPE
-        gcovr -j $(nproc) --delete --root ../source/ --exclude '\.\./source/' --print-summary --xml-pretty --xml coverage.xml .
+        gcovr -j $(nproc) --delete --root ../source/ --exclude '\.\./source/test/' --print-summary --xml-pretty --xml coverage.xml .
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v2

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -43,7 +43,7 @@ jobs:
       working-directory: ${{github.workspace}}/build
       run: |
         ctest -V -C $BUILD_TYPE
-        gcovr -j $(nproc) --delete --root ../source/ -e *.test.cpp --print-summary --xml-pretty --xml coverage.xml .
+        gcovr -j $(nproc) --delete --root ../source/ -e '.*\.test\.cpp' --print-summary --xml-pretty --xml coverage.xml .
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v2

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -43,7 +43,7 @@ jobs:
       working-directory: ${{github.workspace}}/build
       run: |
         ctest -V -C $BUILD_TYPE
-        gcovr -j $(nproc) --delete --root ../source/ -e '\.\./source/test/.*' --print-summary --xml-pretty --xml coverage.xml .
+        gcovr -j $(nproc) --delete --root ../source/ --exclude '\.\./source/' --print-summary --xml-pretty --xml coverage.xml .
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v2

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -28,12 +28,14 @@ jobs:
         cmake -D CMAKE_BUILD_TYPE=$BUILD_TYPE -D CXXP_ENABLE_COVERAGE=ON -B build -S .
         cmake --build build --config $BUILD_TYPE
 
-    - name: Run tests
+    - name: Run tests & generate coverage
       working-directory: ${{github.workspace}}/build
-      run: ctest -V -C $BUILD_TYPE
+      run: |
+        ctest -V -C $BUILD_TYPE
+        gcovr -j $(nproc) --delete --root ../ --print-summary --xml-pretty --xml coverage.xml .
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v2
       with:
-        working-directory: ${{github.workspace}}/build
+        files: ${{github.workspace}}/build/coverage.xml
         fail_ci_if_error: true

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -23,17 +23,10 @@ jobs:
       with:
         cmake-version: 3.18
 
-    - name: Install GCC 11
-      run: |
-          sudo apt-get install gcc-11 g++-11
-
     - name: Build
       run: |
         cmake -D CMAKE_BUILD_TYPE=$BUILD_TYPE -D CXXP_ENABLE_COVERAGE=ON -B build -S .
         cmake --build build --config $BUILD_TYPE
-      env:
-        CC: gcc-11
-        CXX: g++-11
 
     - name: Run tests
       working-directory: ${{github.workspace}}/build

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -38,9 +38,9 @@ jobs:
     - name: Run tests
       working-directory: ${{github.workspace}}/build
       run: ctest -V -C $BUILD_TYPE
-    
+
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v2.1.0
       with:
         working-directory: ${{github.workspace}}/build
         fail_ci_if_error: true

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -23,6 +23,10 @@ jobs:
       with:
         cmake-version: 3.18
 
+    - name: Set up gcovr
+      run: |
+        pip install gcovr
+
     - name: Build
       run: |
         cmake -D CMAKE_BUILD_TYPE=$BUILD_TYPE -D CXXP_ENABLE_COVERAGE=ON -B build -S .

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -40,7 +40,7 @@ jobs:
       run: ctest -V -C $BUILD_TYPE
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v2.1.0
+      uses: codecov/codecov-action@v2
       with:
         working-directory: ${{github.workspace}}/build
         fail_ci_if_error: true

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -36,7 +36,7 @@ jobs:
       working-directory: ${{github.workspace}}/build
       run: |
         ctest -V -C $BUILD_TYPE
-        gcovr -j $(nproc) --delete --root ../ --print-summary --xml-pretty --xml coverage.xml .
+        gcovr -j $(nproc) --delete --root ../source/ --print-summary --xml-pretty --xml coverage.xml .
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v2

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -43,7 +43,7 @@ jobs:
       working-directory: ${{github.workspace}}/build
       run: |
         ctest -V -C $BUILD_TYPE
-        gcovr -j $(nproc) --delete --root ../source/ -e '.*\.test\.cpp' --print-summary --xml-pretty --xml coverage.xml .
+        gcovr -j $(nproc) --delete --root ../source/ -e '^test/.*' --print-summary --xml-pretty --xml coverage.xml .
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v2

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -23,10 +23,17 @@ jobs:
       with:
         cmake-version: 3.18
 
+    - name: Install GCC 11
+      run: |
+          sudo apt-get install gcc-11 g++-11
+
     - name: Build
       run: |
         cmake -D CMAKE_BUILD_TYPE=$BUILD_TYPE -D CXXP_ENABLE_TESTING=ON -B build -S .
         cmake --build build --config $BUILD_TYPE
+      env:
+        CC: gcc-11
+        CXX: g++-11
 
     - name: Run tests
       working-directory: ${{github.workspace}}/build

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -23,10 +23,17 @@ jobs:
       with:
         cmake-version: 3.18
 
+    - name: Set up gcc-11 & g++-11
+      run: |
+        sudo apt-get install gcc-11 g++-11
+
     - name: Build
       run: |
         cmake -D CMAKE_BUILD_TYPE=$BUILD_TYPE -D CXXP_ENABLE_TESTING=ON -B build -S .
         cmake --build build --config $BUILD_TYPE
+      env:
+        CC: gcc-11
+        CXX: g++-11
 
     - name: Run tests
       working-directory: ${{github.workspace}}/build

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -23,17 +23,10 @@ jobs:
       with:
         cmake-version: 3.18
 
-    - name: Install GCC 11
-      run: |
-          sudo apt-get install gcc-11 g++-11
-
     - name: Build
       run: |
         cmake -D CMAKE_BUILD_TYPE=$BUILD_TYPE -D CXXP_ENABLE_TESTING=ON -B build -S .
         cmake --build build --config $BUILD_TYPE
-      env:
-        CC: gcc-11
-        CXX: g++-11
 
     - name: Run tests
       working-directory: ${{github.workspace}}/build

--- a/cmake/fetch-deps.cmake
+++ b/cmake/fetch-deps.cmake
@@ -3,7 +3,7 @@ include(FetchContent)
 FetchContent_Declare(
   googletest
   GIT_REPOSITORY https://github.com/google/googletest.git
-  GIT_TAG release-1.10.0
+  GIT_TAG release-1.11.0
 )
 
 FetchContent_MakeAvailable(

--- a/tools/build-deps.py
+++ b/tools/build-deps.py
@@ -43,11 +43,15 @@ def build_deps(
   if os.path.exists('_tmp'):
       shutil.rmtree('_tmp')
 
-os.chdir('..')
+def main():
+  os.chdir('..')
 
-build_deps('build-deps-debug-x86', 'Debug', 'x86', 'Win32', 'Visual Studio 16 2019', 'MultiThreadedDebug', False)
-build_deps('build-deps-debug-x64', 'Debug', 'x64', 'x64', 'Visual Studio 16 2019', 'MultiThreadedDebug', False)
-build_deps('build-deps-release-x86', 'Release', 'x86', 'Win32', 'Visual Studio 16 2019', 'MultiThreaded', False)
-build_deps('build-deps-release-x64', 'Release', 'x64', 'x64', 'Visual Studio 16 2019', 'MultiThreaded', True)
+  build_deps('build-deps-debug-x86', 'Debug', 'x86', 'Win32', 'Visual Studio 16 2019', 'MultiThreadedDebug', False)
+  build_deps('build-deps-debug-x64', 'Debug', 'x64', 'x64', 'Visual Studio 16 2019', 'MultiThreadedDebug', False)
+  build_deps('build-deps-release-x86', 'Release', 'x86', 'Win32', 'Visual Studio 16 2019', 'MultiThreaded', False)
+  build_deps('build-deps-release-x64', 'Release', 'x64', 'x64', 'Visual Studio 16 2019', 'MultiThreaded', True)
 
-os.chdir('tools')
+  os.chdir('tools')
+
+if __name__ == '__main__':
+  main()

--- a/tools/gen-cmake.py
+++ b/tools/gen-cmake.py
@@ -78,4 +78,8 @@ def gen_cmake(folder: str, target_name: str):
   clean_subdirs(folder)
   write_subdirs(folder, target_name)
 
-gen_cmake(os.path.join('..', 'source'), '${CXXP_EXE}')
+def main():
+  gen_cmake(os.path.join('..', 'source'), '${CXXP_EXE}')
+
+if __name__ == '__main__':
+  main()

--- a/tools/gen-vs.py
+++ b/tools/gen-vs.py
@@ -23,38 +23,42 @@ def gen_group(tag: str, files: list):
     s += '\n  ';
   return s;
 
-headers_list = get_sources(os.path.join('..', 'source'), 'source', '*.h')
-sources_list = get_sources(os.path.join('..', 'source'), 'source', '*.cpp')
+def main():
+  headers_list = get_sources(os.path.join('..', 'source'), 'source', '*.h')
+  sources_list = get_sources(os.path.join('..', 'source'), 'source', '*.cpp')
 
-includes = gen_group('ClInclude', headers_list)
-compiles = gen_group('ClCompile', sources_list)
+  includes = gen_group('ClInclude', headers_list)
+  compiles = gen_group('ClCompile', sources_list)
 
-guid_sln_project = '{' + str(uuid.uuid1()).upper() + '}'
-guid_project     = '{' + str(uuid.uuid1()).upper() + '}'
-guid_solution    = '{' + str(uuid.uuid1()).upper() + '}'
+  guid_sln_project = '{' + str(uuid.uuid1()).upper() + '}'
+  guid_project     = '{' + str(uuid.uuid1()).upper() + '}'
+  guid_solution    = '{' + str(uuid.uuid1()).upper() + '}'
 
-def process(path: str):
-  content = open(path).read()
+  def process(path: str):
+    content = open(path).read()
 
-  return content.replace(
-    '{{GUID-SLN-PROJECT}}', guid_sln_project).replace(
-    '{{GUID-PROJECT}}', guid_project).replace(
-    '{{GUID-SOLUTION}}', guid_solution).replace(
-    '{{INCLUDE}}', includes).replace(
-    '{{COMPILE}}', compiles)
+    return content.replace(
+      '{{GUID-SLN-PROJECT}}', guid_sln_project).replace(
+      '{{GUID-PROJECT}}', guid_project).replace(
+      '{{GUID-SOLUTION}}', guid_solution).replace(
+      '{{INCLUDE}}', includes).replace(
+      '{{COMPILE}}', compiles)
 
-def write_to(path: str, content: str):
-  dir = os.path.dirname(path)
+  def write_to(path: str, content: str):
+    dir = os.path.dirname(path)
 
-  if not os.path.exists(dir):
-    os.makedirs(dir)
+    if not os.path.exists(dir):
+      os.makedirs(dir)
 
-  open(path, 'w').write(content)
+    open(path, 'w').write(content)
 
-write_to(
-  os.path.join('..', 'cxx-project.sln'),
-  process(os.path.join('vs', 'sln.in')))
+  write_to(
+    os.path.join('..', 'cxx-project.sln'),
+    process(os.path.join('vs', 'sln.in')))
 
-write_to(
-  os.path.join('..', 'cxx-project.vcxproj'),
-  process(os.path.join('vs', 'vcxproj.in')))
+  write_to(
+    os.path.join('..', 'cxx-project.vcxproj'),
+    process(os.path.join('vs', 'vcxproj.in')))
+
+if __name__ == '__main__':
+  main()


### PR DESCRIPTION
- Use `googletest` version `1.11.0`.
- Add `__name__` checks for python tools.
- Use `gcc-11` & `g++-11`.
- Use `Codecov` version `v2`.